### PR TITLE
Changes pre-commit hook to use python 3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.6
       exclude: |
         (?x)(
           ^proto/|


### PR DESCRIPTION
Uses Python 3.6 as the standard version.
The Makefile, Travis, Pipenv and the setup.py are already using this version.